### PR TITLE
Downgrade requirements for sqlite package

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -14,7 +14,7 @@ tracky_sources = [
 tracky_deps = [
   dependency('gio-2.0', version: '>= 2.50'),
   dependency('gtk+-3.0', version: '>= 3.22'),
-  dependency('sqlite3', version: '>= 3.28'),
+  dependency('sqlite3', version: '>= 3.26'),
   dependency('gee-0.8', version: '>= 0.20'),
   dependency('libnotify', version: '>= 0.7'),
 ]


### PR DESCRIPTION
Non of actual distributions provide 3.28 version except Arch Linux.